### PR TITLE
update geopandas code

### DIFF
--- a/geopandas/distance.py
+++ b/geopandas/distance.py
@@ -1,6 +1,8 @@
 import os
 import timeit
 import geopandas
+import shapely
+import numpy as np
 import pandas as pd
 
 wd = os.getcwd()
@@ -12,20 +14,23 @@ t_list = [None] * 10
 for i in range(10):
     tic = timeit.default_timer()
 
-    dist = gdf.geometry.apply(lambda f: gdf.distance(f))
+    dist = shapely.distance(
+        np.repeat(gdf.geometry.array.to_numpy().reshape(4000, 1), 4000, 1),
+        np.repeat(gdf.geometry.array.to_numpy().reshape(1, 4000), 4000, 0),
+    )
 
-    # this can get a tiny bit faster using pygeos directly (3.57s vs 3.96s)
-    # import pygeos
-    # dist = pygeos.distance(
-    #     numpy.repeat(gdf.geometry.array.data.reshape(4000, 1), 4000, 1),
-    #     numpy.repeat(gdf.geometry.array.data.reshape(1, 4000), 4000, 0)
-    # )
+    # the same could be done with the following but NxN distance matrix
+    # shall be optimally computed using shapely. The time difference
+    # on M1 Air is 0.372 vs 0.488
+
+    # dist = gdf.geometry.apply(lambda f: gdf.distance(f))
 
     toc = timeit.default_timer()
     t_list[i] = round(toc - tic, 2)
-    
-df = {'task': ['distance'] * 10, 'package': ['geopandas'] * 10, 'time': t_list}
+
+df = {"task": ["distance"] * 10, "package": ["geopandas"] * 10, "time": t_list}
 df = pd.DataFrame.from_dict(df)
-if not os.path.isdir('results'): os.mkdir('results')
-savepath = os.path.join('results', 'distance-geopandas.csv')
-df.to_csv(savepath, index = False, decimal = ',', sep = ';')
+if not os.path.isdir("results"):
+    os.mkdir("results")
+savepath = os.path.join("results", "distance-geopandas.csv")
+df.to_csv(savepath, index=False, decimal=",", sep=";")

--- a/geopandas/distance.py
+++ b/geopandas/distance.py
@@ -1,8 +1,8 @@
 import os
 import timeit
 import geopandas
-import shapely
-import numpy as np
+# import shapely
+# import numpy as np
 import pandas as pd
 
 wd = os.getcwd()
@@ -14,16 +14,12 @@ t_list = [None] * 10
 for i in range(10):
     tic = timeit.default_timer()
 
-    dist = shapely.distance(
-        np.repeat(gdf.geometry.array.to_numpy().reshape(4000, 1), 4000, 1),
-        np.repeat(gdf.geometry.array.to_numpy().reshape(1, 4000), 4000, 0),
-    )
+    dist = gdf.geometry.apply(lambda f: gdf.distance(f))
 
-    # the same could be done with the following but NxN distance matrix
-    # shall be optimally computed using shapely. The time difference
-    # on M1 Air is 0.372 vs 0.488
-
-    # dist = gdf.geometry.apply(lambda f: gdf.distance(f))
+    # dist = shapely.distance(
+    #     np.repeat(gdf.geometry.array.to_numpy().reshape(4000, 1), 4000, 1),
+    #     np.repeat(gdf.geometry.array.to_numpy().reshape(1, 4000), 4000, 0),
+    # )
 
     toc = timeit.default_timer()
     t_list[i] = round(toc - tic, 2)

--- a/geopandas/intersects.py
+++ b/geopandas/intersects.py
@@ -1,7 +1,6 @@
 import os
 import timeit
-import pandas
-import numpy
+
 import geopandas
 import pandas as pd
 
@@ -11,24 +10,20 @@ points = geopandas.read_file(points_path)
 polygon_path = os.path.join(wd, "data", "polygon.gpkg")
 polygon = geopandas.read_file(polygon_path)
 
-# this function is much faster than loop checking all points
-def intersects(points, polygon):
-    hit = points.sindex.query(polygon.geometry.iloc[0], predicate = "intersects")
-    out = numpy.zeros(shape = points.shape, dtype = numpy.bool_)
-    out[hit] = True
-    return out
-
 t_list = [None] * 10
 for i in range(10):
     tic = timeit.default_timer()
 
-    output = intersects(points, polygon)
+    output = points.sindex.query(
+        polygon.geometry.iloc[0], predicate="intersects", output_format="dense"
+    )
 
     toc = timeit.default_timer()
     t_list[i] = round(toc - tic, 2)
-    
-df = {'task': ['intersects'] * 10, 'package': ['geopandas'] * 10, 'time': t_list}
+
+df = {"task": ["intersects"] * 10, "package": ["geopandas"] * 10, "time": t_list}
 df = pd.DataFrame.from_dict(df)
-if not os.path.isdir('results'): os.mkdir('results')
-savepath = os.path.join('results', 'intersects-geopandas.csv')
-df.to_csv(savepath, index = False, decimal = ',', sep = ';')
+if not os.path.isdir("results"):
+    os.mkdir("results")
+savepath = os.path.join("results", "intersects-geopandas.csv")
+df.to_csv(savepath, index=False, decimal=",", sep=";")

--- a/geopandas/load.py
+++ b/geopandas/load.py
@@ -13,11 +13,14 @@ for i in range(10):
 
     gdf = geopandas.read_file(vec)
 
-    # we are working on a new engine - pyogrio (3.02s vs 145ms)
-    # gdf = pyogrio.read_dataframe(vec)
+    # if we have pyarrow in the environment, you can pass data using
+    # arrow stream - 0.163s vs 0.32s
+
+    # gdf = geopandas.read_file(vec, use_arrow=True)
+
     toc = timeit.default_timer()
     t_list[i] = round(toc - tic, 2)
-    
+
 df = {'task': ['load'] * 10, 'package': ['geopandas'] * 10, 'time': t_list}
 df = pd.DataFrame.from_dict(df)
 if not os.path.isdir('results'): os.mkdir('results')

--- a/geopandas/write.py
+++ b/geopandas/write.py
@@ -3,7 +3,6 @@ import timeit
 import tempfile
 import geopandas
 import pandas as pd
-# import pyogrio
 
 wd = os.getcwd()
 vec = os.path.join(wd, "data", "points.gpkg")
@@ -17,16 +16,18 @@ for i in range(10):
     with tempfile.TemporaryDirectory() as tmpdir:
         filename = os.path.join(tmpdir, "test_file.gpkg")
         gdf.to_file(filename)
-    # as with read, pyogrio is much faster in writing (10.5s vs 3.79s)
-    # but the released version is not able to write to
-    # virtual file, so this would fail
-    # pyogrio.write_dataframe(gdf, "path")
+
+        # if we have pyarrow in the environment, you can pass data using
+        # arrow stream - 0.68s vs 0.758s
+
+        # gdf.to_file(filename, use_arrow=True)
 
     toc = timeit.default_timer()
     t_list[i] = round(toc - tic, 2)
-    
-df = {'task': ['write'] * 10, 'package': ['geopandas'] * 10, 'time': t_list}
+
+df = {"task": ["write"] * 10, "package": ["geopandas"] * 10, "time": t_list}
 df = pd.DataFrame.from_dict(df)
-if not os.path.isdir('results'): os.mkdir('results')
-savepath = os.path.join('results', 'write-geopandas.csv')
-df.to_csv(savepath, index = False, decimal = ',', sep = ';')
+if not os.path.isdir("results"):
+    os.mkdir("results")
+savepath = os.path.join("results", "write-geopandas.csv")
+df.to_csv(savepath, index=False, decimal=",", sep=";")

--- a/run_benchmarks.sh
+++ b/run_benchmarks.sh
@@ -22,7 +22,7 @@ do
   for path in "${i}"/*
   do
     echo "$path"
-    python3 "$path"
+    pixi run python "$path"
   done
 done
 


### PR DESCRIPTION
This updates geopandas code to match the current state of the API.

I don't know what the rules are and I might be breaking some.

The distance benchmark is NxN which is very academic imho as you would typically avoid doing such a thing. Hence geopandas does not directly support it and if you want it and performance matters, you should use shapely broadcasting yourself. So that is what I am doing here.

With I/O, we have an option to use ArrowStream when interfacing with GDAL, provided `pyarrow` is installed. I did not implement that but made a comment in there that we could. Especially on read side, it can help significantly.

Most of the other changes are just from a Python linter, to follow PEP8 style guide. Can be ignored, makes no difference to performance.